### PR TITLE
書店情報に紐付けるタグを表示できるようにしました

### DIFF
--- a/app/controllers/bookstores_controller.rb
+++ b/app/controllers/bookstores_controller.rb
@@ -1,14 +1,20 @@
 class BookstoresController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
   before_action :set_bookstore, only: %i[edit update destroy]
-  
+
   def index
     @bookstores = Bookstore.includes(:user).order(created_at: :desc)
+  end
+
+  def show
+    @bookstore = Bookstore.find(params[:id])
   end
 
   def new
     @bookstore = Bookstore.new
   end
+
+  def edit; end
 
   def create
     @bookstore = current_user.bookstores.build(bookstore_params)
@@ -19,12 +25,6 @@ class BookstoresController < ApplicationController
       render :new, status: :unprocessable_entity
     end
   end
-
-  def show
-    @bookstore = Bookstore.find(params[:id])
-  end
-
-  def edit; end
 
   def update
     if @bookstore.update(bookstore_params)
@@ -43,7 +43,7 @@ class BookstoresController < ApplicationController
   private
 
   def bookstore_params
-    params.require(:bookstore).permit(:name, :address)
+    params.require(:bookstore).permit(:name, :address, tag_ids: [])
   end
 
   def set_bookstore

--- a/app/models/bookstore.rb
+++ b/app/models/bookstore.rb
@@ -3,4 +3,6 @@ class Bookstore < ApplicationRecord
   validates :address, presence: true, length: { maximum: 255 }
 
   belongs_to :user
+  has_many :tag_relations, dependent: :destroy
+  has_many :tags, through: :tag_relations
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :tag_relations, dependent: :destroy
+  has_many :bookstores, through: :tag_relations
+
+  validates :name, presence: true, length: { maximum: 20 }
+end

--- a/app/models/tag_relation.rb
+++ b/app/models/tag_relation.rb
@@ -1,0 +1,4 @@
+class TagRelation < ApplicationRecord
+  belongs_to :tag
+  belongs_to :bookstore
+end

--- a/app/views/bookstores/_bookstore.html.erb
+++ b/app/views/bookstores/_bookstore.html.erb
@@ -1,10 +1,14 @@
-<div class="card"> 
-  <div class="card-header">
-    書店情報No.<%= bookstore.id %>
-  </div>
-  <div class="card-body">
-    <h5 class="card-title"><%= bookstore.name %></h5>
-    <p class="card-text"><%= bookstore.address %></p>
-    <%= link_to t('bookstores.index.to_show_bookstore'), bookstore_path(bookstore) , class: "btn btn-primary"%> 
+<div class="col-sm-12 col-lg-4 mb-3">
+  <div id="bookstore-id-<%= bookstore.id %>">
+    <div class="card"> 
+      <div class="card-header">
+        書店情報No.<%= bookstore.id %>
+      </div>
+      <div class="card-body">
+        <h5 class="card-title"><%= bookstore.name %></h5>
+        <p class="card-text"><%= bookstore.address %></p>
+        <%= link_to t('bookstores.index.to_show_bookstore'), bookstore_path(bookstore) , class: "btn btn-primary"%> 
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/bookstores/_form.html.erb
+++ b/app/views/bookstores/_form.html.erb
@@ -8,6 +8,10 @@
       <%= f.label :address, class: "form-label" %>
       <%= f.text_field :address, class: "form-control" %>
     </div>
+    <div class="mb-3">
+      <p>どんなものが当てはまりますか？(複数タグを選びたい場合はshiftキーを押しながら選択してください)</p>
+      <%= f.collection_select :tag_ids, Tag.all, :id, :name, {}, { multiple: true, size: 10, name: "bookstore[tag_ids][]" } %>
+    </div>
 
-    <%= f.submit "作成", class: "btn btn-primary" %>
+    <%= f.submit nil, class: "btn btn-primary" %>
     <% end %>

--- a/app/views/bookstores/index.html.erb
+++ b/app/views/bookstores/index.html.erb
@@ -1,9 +1,11 @@
 <h1><%= t('.title') %></h1>
-
-<% if @bookstores.present? %>
-  <%= render @bookstores %>
-  <% else %>
-    <div class="mb-3">書店情報がありません</div>
-  <% end %>
-  <div class="text-center">
-    <%= link_to t('.to_create_bookstore'), new_bookstore_path %>
+  <div class="row">
+    <% if @bookstores.present? %>
+      <%= render @bookstores %>
+    <% else %>
+      <div class="mb-3">書店情報がありません</div>
+    <% end %>
+    <div class="text-center">
+      <%= link_to t('.to_create_bookstore'), new_bookstore_path %>
+    </div>
+  </div>

--- a/app/views/bookstores/show.html.erb
+++ b/app/views/bookstores/show.html.erb
@@ -1,7 +1,7 @@
 <h1><%= t('.title') %></h1>
 
 <div class="container">
-
+  <div class="d-flex">
   <h3><%= @bookstore.name %></h3>
   <i class="bi bi-bookmark"></i>
   <%= link_to edit_bookstore_path(@bookstore), class: "button-edit-#{@bookstore.id}" do %>
@@ -10,15 +10,22 @@
   <%= link_to bookstore_path(@bookstore), class: "button-delete-#{@bookstore.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.flash_message.delete') } do %>
     <i class="bi bi-trash"></i>
   <% end %>
+  </div>
 
   <div>
     場所：<%= @bookstore.address %>
   </div>
   <div>
-    どんなところ？
+    <p>タグ</p>
+    <% @bookstore.tags.each do |tag| %>
+    <%= link_to bookstores_path(tag_name: tag.name), class: "badge rounded-pill bg-primary text-decoration-none text-white" do %>
+      <%= tag.name %>
+    <% end %>
+    <% end %>
   </div>
-
+  <div>
   <%= link_to "この本屋のおすすめ文を書いてみる", "#" %>
+  </div>
+  <%= link_to "本屋一覧へ", bookstores_path %>
 
-  
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
   <head>
     <title>BookstoreVisitor</title>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="fixed-bottom">
+<footer>
 <nav class="navbar navbar-expand-lg navigation navbar-light bg-light">
 
 <div class="collapse navbar-collapse">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -31,7 +31,7 @@ ja:
       success: ログアウトしました
   bookstores:
     index:
-      title: 本屋情報一覧
+      title: このアプリに登録された本屋
       to_create_bookstore: 新しく本屋情報を追加する
       to_show_bookstore: 本屋詳細ページへ
     new:

--- a/db/migrate/20240518070110_create_tags.rb
+++ b/db/migrate/20240518070110_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.string :name,         null: false
+
+      t.timestamps
+    end
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20240518075745_create_tag_relations.rb
+++ b/db/migrate/20240518075745_create_tag_relations.rb
@@ -1,0 +1,11 @@
+class CreateTagRelations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tag_relations do |t|
+      t.references :tag, null: false, foreign_key: true
+      t.references :bookstore, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :tag_relations, [:tag_id, :bookstore_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_16_015853) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_18_075745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,23 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_16_015853) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_bookstores_on_user_id"
+  end
+
+  create_table "tag_relations", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "bookstore_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bookstore_id"], name: "index_tag_relations_on_bookstore_id"
+    t.index ["tag_id", "bookstore_id"], name: "index_tag_relations_on_tag_id_and_bookstore_id", unique: true
+    t.index ["tag_id"], name: "index_tag_relations_on_tag_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -38,4 +55,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_16_015853) do
   end
 
   add_foreign_key "bookstores", "users"
+  add_foreign_key "tag_relations", "bookstores"
+  add_foreign_key "tag_relations", "tags"
 end


### PR DESCRIPTION
ひとまずタグを表示できるようにしましたが、ユーザビリティの向上のため表示方法を変更するかもしれません。

前回閉じ損ねた「書店情報の編集・削除機能」もこのプルリクエストでクローズします。

Closes #12, #16 